### PR TITLE
Use fast_ignore instead of `git ls-files`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /.bundle/
 /coverage/
 /pkg/
+/vendor/
 .rspec_status
 *.gem
 Gemfile.lock

--- a/.spellr_wordlists/english.txt
+++ b/.spellr_wordlists/english.txt
@@ -35,6 +35,7 @@ params
 pathspec
 pwd
 rdoc
+readme
 regexp
 rspec
 rubo

--- a/fast_ignore.gemspec
+++ b/fast_ignore.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     spec.metadata['changelog_uri'] = 'https://github.com/robotdana/fast_ignore/blob/master/CHANGELOG.md'
   end
 
-  spec.files = FastIgnore.new(include_rules: ['bin/*', 'lib/**/*', 'LICENSE.txt', 'README.md'], relative: true).sort
+  spec.files = FastIgnore.new(include_rules: ['CHANGELOG.md', 'lib', 'LICENSE.txt', 'README.md'], relative: true).sort
   spec.require_paths = ['lib']
 
   spec.add_development_dependency 'bundler', '>= 1.17'

--- a/fast_ignore.gemspec
+++ b/fast_ignore.gemspec
@@ -2,6 +2,7 @@
 
 lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'fast_ignore'
 require 'fast_ignore/version'
 
 Gem::Specification.new do |spec|
@@ -22,11 +23,7 @@ Gem::Specification.new do |spec|
     spec.metadata['changelog_uri'] = 'https://github.com/robotdana/fast_ignore/blob/master/CHANGELOG.md'
   end
 
-  # Specify which files should be added to the gem when it is released.
-  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  spec.files = Dir.chdir(File.expand_path(__dir__)) do
-    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  end
+  spec.files = FastIgnore.new(include_rules: ['bin/*', 'lib/**/*', 'LICENSE.txt', 'README.md'], relative: true).sort
   spec.require_paths = ['lib']
 
   spec.add_development_dependency 'bundler', '>= 1.17'


### PR DESCRIPTION
Hello,

This PR does two of the following things:
- It uses `fast_ignore` instead of `git ls-files` because:
  - this way we can drop the unnecessary dependency on git.
  - use what this project is intended to do :heart: 
  - ...because why not? :)

- Adds `/vendor/` to the `.gitignore` file.  
  That is because when `bundle install` is run, it creates a `vendor/` directory which should not be committed.


Given that these are two different things, I had them committed separately.
If it makes sense, don't squash them while merging either \o/

Thanks for your work on this! :100: 